### PR TITLE
Randall fixes

### DIFF
--- a/rek_osx_tag.py
+++ b/rek_osx_tag.py
@@ -3,57 +3,53 @@ import os
 import subprocess
 from optparse import OptionParser
 
-parser = OptionParser()
-parser.add_option("-d", "--directory", 
-    dest="source_directory",
-    default=".",
-    help="Specify directory of photos to tag e.g. /Media/Photos/")
+def gettags(sourceimage):
+    """Returns Tags for requested image"""
+    taglist = []
+    client = boto3.client('rekognition')
 
-(options, args) = parser.parse_args()
+    print "Analyzing ", sourceimage
+    with open(sourceimage, 'rb') as image:
 
-sourceDirectory = options.source_directory
-minConfidence = 50
+        response = client.detect_labels(
+            Image={'Bytes': image.read()},
+            MaxLabels=50,
+            MinConfidence=minConfidence
+        )
+
+    for tag in response["Labels"]:
+        print tag["Confidence"], tag["Name"]
+        taglist.append(tag["Name"])
+
+    return taglist
+
+def writexattrs(F, TagList):
+    print "Setting following tags for ", F, " ", TagList
+    Result = ""
+    plistFront = '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><array>'
+    plistEnd = '</array></plist>'
+    plistTagString = ''
+    for Tag in TagList:
+        plistTagString = plistTagString + '<string>{}</string>'.format(Tag.replace("'","-"))
+    TagText = plistFront + plistTagString + plistEnd
+
+    OptionalTag = "com.apple.metadata:"
+    XattrList = ["kMDItemFinderComment","_kMDItemUserTags","kMDItemOMUserTags"]
+    for Field in XattrList:
+        XattrCommand = 'xattr -w {0} \'{1}\' "{2}"'.format(OptionalTag + Field,TagText.encode("utf8"),F)
+        ProcString = subprocess.check_output(XattrCommand, stderr=subprocess.STDOUT,shell=True)
+        Result += ProcString
+    return Result
 
 if __name__ == '__main__':
-
-    def gettags(sourceimage):
-        """Returns Tags for requested image"""
-        
-        taglist = []
-        client = boto3.client('rekognition')
-
-        print "Analyzing ", sourceimage
-        with open(sourceimage, 'rb') as image:
-
-            response = client.detect_labels(
-                Image={'Bytes': image.read()},
-                MaxLabels=50,
-                MinConfidence=minConfidence
-            )
-
-        for tag in response["Labels"]:
-            print tag["Confidence"], tag["Name"]
-            taglist.append(tag["Name"])
-        
-        return taglist
-
-    def writexattrs(F,TagList):
-        print "Setting following tags for ", F, " ", TagList
-        Result = ""
-        plistFront = '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><array>'
-        plistEnd = '</array></plist>'
-        plistTagString = ''
-        for Tag in TagList:
-            plistTagString = plistTagString + '<string>{}</string>'.format(Tag.replace("'","-"))
-        TagText = plistFront + plistTagString + plistEnd
-
-        OptionalTag = "com.apple.metadata:"
-        XattrList = ["kMDItemFinderComment","_kMDItemUserTags","kMDItemOMUserTags"]
-        for Field in XattrList:    
-            XattrCommand = 'xattr -w {0} \'{1}\' "{2}"'.format(OptionalTag + Field,TagText.encode("utf8"),F)
-            ProcString = subprocess.check_output(XattrCommand, stderr=subprocess.STDOUT,shell=True) 
-            Result += ProcString
-        return Result
+    parser = OptionParser()
+    parser.add_option("-d", "--directory",
+        dest="source_directory",
+        default=".",
+        help="Specify directory of photos to tag e.g. /Media/Photos/")
+    (options, args) = parser.parse_args()
+    sourceDirectory = options.source_directory
+    minConfidence = 50
 
     for fn in os.listdir(sourceDirectory):
         imagename = sourceDirectory + "/" + fn

--- a/rek_osx_tag.py
+++ b/rek_osx_tag.py
@@ -1,64 +1,88 @@
+"""Loops through directory and gathers Rekogition tags for each image."""
+from __future__ import print_function
 import boto3
 import os
 import subprocess
 from optparse import OptionParser
+import mimetypes
+import concurrent.futures
+import sys
+if sys.version_info[0] < 3:
+    from itertools import izip_longest as zip_longest
+else:
+    from itertools import zip_longest
 
-def gettags(sourceimage):
+
+def gettags(source_image, client):
     """Returns Tags for requested image"""
-    taglist = []
-    client = boto3.client('rekognition')
-
-    print "Analyzing ", sourceimage
-    with open(sourceimage, 'rb') as image:
-
+    with open(source_image, 'rb') as image:
         response = client.detect_labels(
             Image={'Bytes': image.read()},
             MaxLabels=50,
-            MinConfidence=minConfidence
+            MinConfidence=50
         )
+    return [tag["Name"] for tag in response["Labels"]]
 
-    for tag in response["Labels"]:
-        print tag["Confidence"], tag["Name"]
-        taglist.append(tag["Name"])
 
-    return taglist
+def writexattrs(fn, tags):
+    print("Setting following tags for ", fn, " ", tags)
+    plist = """\
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+        <array>{}</array>
+    </plist>"""
+    tag_string = ''.join(['<string>{}</string>'.format(tag.replace("'", "-")) for tag in tags])
+    plist = plist.format(tag_string)
+    optional_tag = "com.apple.metadata:"
+    attr_list = ["kMDItemFinderComment", "_kMDItemUserTags", "kMDItemOMUserTags"]
+    for field in attr_list:
+        cmd = 'xattr -w {} \'{}\' "{}"'.format(optional_tag + field, plist, fn)
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
 
-def writexattrs(F, TagList):
-    print "Setting following tags for ", F, " ", TagList
-    Result = ""
-    plistFront = '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><array>'
-    plistEnd = '</array></plist>'
-    plistTagString = ''
-    for Tag in TagList:
-        plistTagString = plistTagString + '<string>{}</string>'.format(Tag.replace("'","-"))
-    TagText = plistFront + plistTagString + plistEnd
 
-    OptionalTag = "com.apple.metadata:"
-    XattrList = ["kMDItemFinderComment","_kMDItemUserTags","kMDItemOMUserTags"]
-    for Field in XattrList:
-        XattrCommand = 'xattr -w {0} \'{1}\' "{2}"'.format(OptionalTag + Field,TagText.encode("utf8"),F)
-        ProcString = subprocess.check_output(XattrCommand, stderr=subprocess.STDOUT,shell=True)
-        Result += ProcString
-    return Result
+def images_in_dir(source_directory):
+    for fn in os.listdir(os.path.expanduser(source_directory)):
+        pth = os.path.join(source_directory, fn)
+        if not os.path.isfile(pth):
+            continue
+        ftype = mimetypes.guess_type(pth)[0]
+        imgsize = os.path.getsize(pth)
+        if ftype not in ["image/png", "image/jpeg"]:
+            print("Skipping {} is not a known type".format(pth))
+            continue
+        if imgsize >= 5242880:
+            print("Skipping {} is over 5242880 bytes".format(pth))
+            continue
+        yield pth
+
+
+def grouper(iterable, n, fillvalue=None):
+    """Collect data into fixed-length chunks or blocks"""
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
+    args = [iter(iterable)] * n
+    return zip_longest(*args, fillvalue=fillvalue)
+
+
+def put_tags(images):
+    client = boto3.client('rekognition')
+    for image in images:
+        if image:
+            try:
+                writexattrs(image, gettags(image, client))
+            except Exception as ex:
+                print(ex, image)
 
 if __name__ == '__main__':
     parser = OptionParser()
-    parser.add_option("-d", "--directory",
+    parser.add_option(
+        "-d", "--directory",
         dest="source_directory",
         default=".",
         help="Specify directory of photos to tag e.g. /Media/Photos/")
     (options, args) = parser.parse_args()
-    sourceDirectory = options.source_directory
-    minConfidence = 50
-
-    for fn in os.listdir(sourceDirectory):
-        imagename = sourceDirectory + "/" + fn
-        imagesize = os.path.getsize(imagename) 
-        print imagename
-        if imagesize > 5242880:
-            print "Skipping %s: filesize exceeds maximum of 5242880 bytes" % imagename
-        elif os.path.isfile(imagename):
-            tags = gettags(fn)
-            writexattrs(imagename, tags)
-        else:
-            print imagename + " is not a file"
+    images = images_in_dir(options.source_directory)
+    # Use as many processes as we have CPU
+    executor = concurrent.futures.ProcessPoolExecutor()
+    # Use groups of 20 for each process
+    futures = [executor.submit(put_tags, group) for group in grouper(images, 20)]
+    concurrent.futures.wait(futures)

--- a/rek_osx_tag.py
+++ b/rek_osx_tag.py
@@ -1,12 +1,13 @@
 """Loops through directory and gathers Rekogition tags for each image."""
 from __future__ import print_function
-import boto3
 import os
 import subprocess
 from optparse import OptionParser
 import mimetypes
 import concurrent.futures
 import sys
+import time
+import boto3
 if sys.version_info[0] < 3:
     from itertools import izip_longest as zip_longest
 else:
@@ -80,9 +81,12 @@ if __name__ == '__main__':
         default=".",
         help="Specify directory of photos to tag e.g. /Media/Photos/")
     (options, args) = parser.parse_args()
-    images = images_in_dir(options.source_directory)
+    start = time.time()
+    images = list(images_in_dir(options.source_directory))
     # Use as many processes as we have CPU
     executor = concurrent.futures.ProcessPoolExecutor()
     # Use groups of 20 for each process
     futures = [executor.submit(put_tags, group) for group in grouper(images, 20)]
     concurrent.futures.wait(futures)
+    end = time.time()
+    print("Processed {} images in {:.2f} seconds".format(len(images), end - start))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+futures

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 futures
+pillow


### PR DESCRIPTION
I tested the timing differences and multiple processes is significantly faster.

`python rek_osx_tag.py -d ~/Dropbox/screenshots  12.32s user 7.28s system 43% cpu 44.878 total`
vs.
`python rek_osx_tag.py -d /Users/randhunt/Dropbox/screenshots  8.78s user 4.83s system 13% cpu 1:39.97 total`

The above only made it through the first few images before it failed.